### PR TITLE
241 support

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("7.5.0.0")]
-[assembly: AssemblyFileVersion("7.5.0.0")]
+[assembly: AssemblyVersion("7.7.0.0")]
+[assembly: AssemblyFileVersion("7.7.0.0")]


### PR DESCRIPTION
…ble with KeePass 2.4.1

Removed dictionary used for SecureEdit now that SecureTextBoxEx does not depend on a TextBox
Updated password get/set operations to work directly on SecureTextBoxEx.TextEx - which exposes the underlying ProtectedString